### PR TITLE
feat(up next): add support for long press on up next home section cards

### DIFF
--- a/app/components/HomeSection.tsx
+++ b/app/components/HomeSection.tsx
@@ -28,9 +28,14 @@ type HomeSectionNavigationProps = StackNavigationProp<RootStackParamList>;
 export default function HomeSection({ data, sectionType }: Props): JSX.Element {
   const { colors, dark } = useTheme();
   const { t } = useTranslation();
+  const [sectionData, setSectionData] = useState([] as BaseItemDto[]);
   const deviceWidth = Dimensions.get('window').width;
   const navigation = useNavigation<HomeSectionNavigationProps>();
   let sectionTitle = '';
+
+  useEffect(() => {
+    setSectionData(data);
+  }, [data]);
 
   switch (sectionType) {
     case 'resumeItems':
@@ -81,6 +86,45 @@ export default function HomeSection({ data, sectionType }: Props): JSX.Element {
       }
     };
 
+    const handleLongPress = () => {
+      if (sectionType === 'resumeItems') {
+        ActionSheetIOS.showActionSheetWithOptions(
+          {
+            options: [
+              'Cancel',
+              'Play',
+              'Play from beginning',
+              'Mark as Played'
+            ],
+            cancelButtonIndex: 0
+          },
+          (buttonIndex) => {
+            switch (buttonIndex) {
+              case 1:
+                navigation.navigate('Play', { itemId: item.id || '' });
+                break;
+              case 2:
+                navigation.navigate('Play', {
+                  itemId: item.id || '',
+                  playFromStart: true
+                });
+                break;
+              case 3: {
+                api.PlaystateApi.markPlayedItem({
+                  userId: api.userInfo.user?.id || '',
+                  itemId: item.id || ''
+                });
+                setSectionData(
+                  sectionData.filter((dataItem) => dataItem.id !== item.id)
+                );
+                break;
+              }
+            }
+          }
+        );
+      }
+    };
+
     return (
       <View
         style={{
@@ -90,6 +134,7 @@ export default function HomeSection({ data, sectionType }: Props): JSX.Element {
       >
         <Pressable
           onPress={handleNavigation}
+          onLongPress={handleLongPress}
           style={[
             {
               minWidth: 100,
@@ -233,7 +278,7 @@ export default function HomeSection({ data, sectionType }: Props): JSX.Element {
       <FlatList
         showsHorizontalScrollIndicator={false}
         horizontal={true}
-        data={data}
+        data={sectionData}
         renderItem={renderItem}
         ListHeaderComponent={
           <View

--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -16,7 +16,7 @@ import AboutScreen from '../scenes/home/UserSettings/About';
 export type RootStackParamList = {
   Home: undefined;
   Library: { libraryId: string; libraryName: string; libraryType: string };
-  Play: { itemId: string };
+  Play: { itemId: string; playFromStart?: boolean };
   Item: { itemId: string };
   'User Settings': undefined;
   About: undefined;

--- a/app/scenes/home/Play.tsx
+++ b/app/scenes/home/Play.tsx
@@ -92,7 +92,10 @@ export default function VideoPlayer({ route }: Props): JSX.Element {
 
   const reportBeginPlayback = (playbackReport: AVPlaybackStatus) => {
     if (playbackReport.isLoaded) {
-      if (itemInfo.userData?.playbackPositionTicks) {
+      if (
+        itemInfo.userData?.playbackPositionTicks &&
+        !route.params.playFromStart
+      ) {
         console.log('Resuming!');
         player.current?.playFromPositionAsync(
           itemInfo.userData?.playbackPositionTicks / 10000


### PR DESCRIPTION
Allows users to mark as played, play, and play from beginning in IOS Action sheet on longpress of
up next card